### PR TITLE
Refine release workflow condition to exclude pre-release branches

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
 
     needs: release_to_github
-    if: contains(github.head_ref, 'release/')
+    if: contains(github.head_ref, 'release/') && !(contains(github.head_ref, 'rc') || contains(github.head_ref, 'beta') || contains(github.head_ref, 'alpha'))
 
     env:
       CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_TOKEN }}


### PR DESCRIPTION
- Update GitHub Actions workflow to prevent release tasks on pre-release branches
- Add checks to skip release for branches containing 'rc', 'beta', or 'alpha'